### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -46,7 +46,7 @@ jobs:
           -Dquarkus.native.container-build=true \
           -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:20.3.0.0.Final-java11
       - name: Push to Quay.io
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: quay.io
           name: carlosthe19916/controls
@@ -109,7 +109,7 @@ jobs:
           yarn install
           yarn build
       - name: Push to Quay.io
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: quay.io
           name: carlosthe19916/controls-ui

--- a/.github/workflows/controls.yml
+++ b/.github/workflows/controls.yml
@@ -47,7 +47,7 @@ jobs:
           -Dquarkus.native.container-build=true \
           -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:20.3.0.0.Final-java11
       - name: Push to Quay.io
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: quay.io
           name: carlosthe19916/controls

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -58,7 +58,7 @@ jobs:
           yarn install
           yarn build
       - name: Push to Quay.io
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: quay.io
           name: carlosthe19916/controls-ui


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore